### PR TITLE
macOS 크래시 오류 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/app.py
+++ b/app.py
@@ -78,8 +78,8 @@ def extract_audio_files(file_list_path):
 
 
 
-
-file_list_path = r".\audio_file_list.txt"
+# os.path.abspath 함수로 경로를 OS에 맞게 수정
+file_list_path = os.path.abspath("./audio_file_list.txt");
 audio_files = extract_audio_files(file_list_path)
 # 서버에서 재생 목록을 랜덤하게 섞음
 shuffled_audio_files = copy.deepcopy(audio_files)


### PR DESCRIPTION
MacOS 등에서 경로명이 원활히 해석되지 못해, 실행이 불가능한 오류를 해결했습니다.

우선 `audio_file_list.txt` 파일에 대한 참조부터 해결했습니다. 추후 이에 관련한 버그 발생 시, 이 PR과 같이 수정할 수 있겠습니다.